### PR TITLE
provide function to snap point and polyline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.3.2, Dec 11, 2023
+* Provide `nearestLatLngOnLine` and `splitRouteByLatLng` function inside `VietmapPolyline` class, which help show shipper/vehicle location on route and remove route traveled by shipper/vehicle.
+* `splitRouteByLatLng` will split route into 2 parts, which are `routeBeforeLatLng` and `routeAfterLatLng`, you can use one of them to to update the route of shipper/vehicle traveled.
+* Create `VietmapPolyline` class to handle more complex polyline
+## 1.3.1, Dec 05, 2023
+* Add document for `StaticMarkerLayer` and `StaticMarker`
 ## 1.3.0, Nov 28, 2023
 * Calculate `StaticMarker` angle when user rotate the map
 ## 1.2.7, Nov 27, 2023

--- a/LICENSE
+++ b/LICENSE
@@ -46,6 +46,8 @@ This project uses the MapLibre GL native libraries for Android and iOS from http
 ------------------------------------------------------------------------------------------------------
 BSD 2-Clause License
 
+Copyright (c) 2023 VietMap Application Co., Ltd.
+
 Copyright (c) 2021 MapLibre contributors
 
 Copyright (c) 2018-2021 MapTiler.com

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ or run this command in the terminal to add the library to the project:
 ```
 ## Android config
 
-
 Add the below code to the build.gradle (project) file at path: **android/build.gradle**
 
 ```gradle
@@ -90,7 +89,7 @@ The map supports the familiar two-finger pinch and zooms to change the zoom leve
 And following operations can be performed using the CameraPosition
 
 #### Target
-The target is single latitude and longitude coordinate that the camera centers it on. Changing the camera's target will move the camera to the inputted coordinates. The target is a LatLng object. The target coordinate is always _at the center of the viewport_.
+The target is a single latitude and longitude coordinate that the camera centers it on. Changing the camera's target will move the camera to the inputted coordinates. The target is a LatLng object. The target coordinate is always _at the center of the viewport_.
 
 
 #### Tilt
@@ -99,7 +98,7 @@ Tilt is the camera's angle from the nadir (directly facing the Earth) and uses u
 The map camera tilt can also adjust by placing two fingertips on the map and moving both fingers up and down in parallel at the same time or
 
 #### Bearing
-Bearing represents the direction that the camera is pointing in and is measured in degrees  _clockwise from north_.
+Bearing represents the direction that the camera is pointing in and is measured in degrees _clockwise__ from north__.
 
 The camera's default bearing is 0 degrees (i.e. "true north") causing the map compass to hide until the camera bearing becomes a non-zero value. Bearing levels use six decimal point precision, which enables you to restrict/set/lock a map's bearing with extreme precision. In addition to programmatically adjusting the camera bearing, the user can place two fingertips on the map and rotate their fingers.
 
@@ -158,9 +157,9 @@ It sets a callback that's invoked when the user clicks on the map:
 ### Add marker (Marked a point in the map with a custom widget)
 - We provide two types of markers, the first is a `simple marker`, and the second is a `static marker`. The simple marker `will not rotate` when the map rotates, and the static marker `will rotate` with the map.
 
-<img src="./gif/marker_demo.gif" alt="drawing" width="200"/>
+<img src="https://github.com/vietmap-company/flutter-map-sdk/raw/main/gif/marker_demo.gif" alt="drawing" width="200"/>
 
-### Add a simple marker (Marked a point in the map with a custom widget, marker will not rotate when the map rotates)
+### Add a simple marker (Marked a point in the map with a custom widget, the marker will not rotate when the map rotates)
 - The marker support anchor with input is an alignment, which requires width and height to calculate the position of the marker, the default for both of them is 20
 - Make sure the `width and height of the marker match with its child's` width and height to the marker display exactly
 
@@ -201,8 +200,8 @@ It sets a callback that's invoked when the user clicks on the map:
     
 ```
 
-### Add a static marker (Marked a point in the map with a custom widget, marker will rotate with the map)
-- The static marker support rotate with input is a bearing, you can find this value when get GPS location.
+### Add a static marker (Marked a point in the map with a custom widget, the marker will rotate with the map)
+- The static marker support rotates with input is a bearing, you can find this value when get GPS location.
 
 - We recommend using this marker for location-based applications, tracking the location of the driver. Then the driver's vehicle will rotate in the right direction even when the user rotates the map at any angle.
 ```dart
@@ -220,13 +219,16 @@ It sets a callback that's invoked when the user clicks on the map:
             width: 50,
             height: 50,
             bearing: 0,
-            child: _markerWidget(Icons.arrow_downward_rounded),
+            child: Container(
+              width: 50,
+              height: 50,
+              child:Icon(Icons.arrow_downward_rounded)),
             latLng: LatLng(10.736657, 106.672240)),
           ]),
   ])
 ```
 
-#### Note: You must enable `trackCameraPosition: true`, at _VietmapGL_, which ensured the MarkerLayer renders normally 
+#### Note: You must enable `trackCameraPosition: true`, at _VietmapGL, which ensures the MarkerLayer renders normally 
 
 ### Add a Line/Polyline (A line connects 2 points on the map)
 
@@ -325,11 +327,47 @@ It sets a callback that's invoked when the user clicks on the map:
     _mapController?.clearPolygons();
 ```
 
+### Find a route between 2 or more points
+- We've created a package to find a route between 2 or more points, you can find the
+[vietmap_flutter_plugin](https://pub.dev/packages/vietmap_flutter_plugin) to use it.
+- Run this command in the terminal to add the library to the project:
+```bash
+  flutter pub add vietmap_flutter_plugin
+```
+- Example code:
+```dart
+  List<LatLng> points = [];
+  /// Get the route between 2 points
+  var routingResponse = await Vietmap.routing(VietMapRoutingParams(points: [
+    const LatLng(21.027763, 105.834160),
+    const LatLng(21.027763, 105.834160)
+  ]));
 
+  /// Handle the response
+  routingResponse.fold((Failure failure) {
+    // handle failure here
+  }, (VietMapRoutingModel success) {
+    if (success.paths?.isNotEmpty == true &&
+        success.paths![0].points?.isNotEmpty == true) {
+      /// import this [import 'package:vietmap_gl_platform_interface/vietmap_gl_platform_interface.dart';] package
+      points =
+          VietmapPolylineDecoder.decodePolyline(success.paths![0].points!);
+    }
+  });
+
+  /// Draw the route on the map
+  Line? line = await _mapController?.addPolyline(
+    PolylineOptions(
+        geometry: points,
+        polylineColor: Colors.red,
+        polylineWidth: 14.0,
+        polylineOpacity: 0.5),
+  );
+```
 <br>
 
 # Troubleshooting
-- Our SDK uses the key to identify the markers and update their location while the user does some gestures, so we strongly recommend you add the key for all of the widgets in the screen which use the map SDK:
+- Our SDK uses the key to identify the markers and update their location while the user does some gestures, so we strongly recommend you add the key for all of the widgets in the screen that use the map SDK:
  ```dart
   Stack(
     children:[
@@ -345,7 +383,7 @@ It sets a callback that's invoked when the user clicks on the map:
  ```
 
 Demo code [here](./example/lib/main.dart)
-# Note: Replace apikey which is provided by VietMap to all _YOUR_API_KEY_HERE_ tag to the application work normally
+## Note: Replace apikey which is provided by VietMap to all _YOUR_API_KEY_HERE_ tag to the application work normally
 
 <br></br>
 <br></br>
@@ -358,5 +396,5 @@ Contact for [support](https://vietmap.vn/lien-he)
 
 Vietmap API document [here](https://maps.vietmap.vn/docs/map-api/overview/)
 
-Have a bug to report? [Open an issue](https://github.com/vietmap-company/flutter-map-sdk/issues). If possible, include a full log and information which shows the issue.
+Have a bug to report? [Open an issue](https://github.com/vietmap-company/flutter-map-sdk/issues). If possible, include a full log and information that shows the issue.
 Have a feature request? [Open an issue](https://github.com/vietmap-company/flutter-map-sdk/issues). Tell us what the feature should do and why you want the feature.

--- a/README.vi.md
+++ b/README.vi.md
@@ -331,6 +331,44 @@ VietmapGL(
     _mapController?.clearPolygons();
 ```
 
+### Tìm đường đi giữa 2 hoặc nhiều điểm
+- Chúng tôi cung cấp package để tìm đường đi giữa 2 hoặc nhiều điểm, bạn có thể tìm package
+[vietmap_flutter_plugin](https://pub.dev/packages/vietmap_flutter_plugin) để sử dụng nó.
+- Chạy lệnh sau trong terminal để thêm thư viện vào project:
+```bash
+  flutter pub add vietmap_flutter_plugin
+```
+
+- Example code:
+```dart
+  List<LatLng> points = [];
+  /// Tìm đường đi giữa 2 điểm
+  var routingResponse = await Vietmap.routing(VietMapRoutingParams(points: [
+    const LatLng(21.027763, 105.834160),
+    const LatLng(21.027763, 105.834160)
+  ]));
+
+  /// Xử lý kết quả trả về
+  routingResponse.fold((Failure failure) {
+    // Xử lý lỗi nếu có
+  }, (VietMapRoutingModel success) {
+    if (success.paths?.isNotEmpty == true &&
+        success.paths![0].points?.isNotEmpty == true) {
+      /// import this [import 'package:vietmap_gl_platform_interface/vietmap_gl_platform_interface.dart';] package
+      points =
+          VietmapPolylineDecoder.decodePolyline(success.paths![0].points!);
+    }
+  });
+
+  /// Vẽ đường đi lên bản đồ
+  Line? line = await _mapController?.addPolyline(
+    PolylineOptions(
+        geometry: points,
+        polylineColor: Colors.red,
+        polylineWidth: 14.0,
+        polylineOpacity: 0.5),
+  );
+```
 
 <br>
 
@@ -352,7 +390,7 @@ VietmapGL(
  ```
 
 Demo code [tại đây](./example/lib/main.dart)
-# Note: Thay thế apikey được cung cấp bởi VietMap vào tất cả các thẻ  **_YOUR_API_KEY_HERE_**  để ứng dụng hoạt động bình thường
+## Lưu ý: Thay thế apikey được cung cấp bởi VietMap vào tất cả các thẻ  **_YOUR_API_KEY_HERE_**  để ứng dụng hoạt động bình thường
 
 <br></br>
 <br></br>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 
 import 'package:vietmap_flutter_gl/vietmap_flutter_gl.dart';
-
+import 'package:vietmap_gl_platform_interface/vietmap_gl_platform_interface.dart';
 import 'dart:math' show Random;
 
 import 'constant.dart';
@@ -102,30 +102,6 @@ class _VietmapExampleMapViewState extends State<VietmapExampleMapView> {
                         bearing: 0,
                         child: _markerWidget(Icons.arrow_upward_outlined),
                         latLng: LatLng(10.759305, 106.675912)),
-                    // StaticMarker(
-                    //     width: 50,
-                    //     height: 50,
-                    //     bearing: 25,
-                    //     child: _markerWidget(Icons.arrow_upward),
-                    //     latLng: LatLng(10.766543, 106.742378)),
-                    // StaticMarker(
-                    //     width: 50,
-                    //     height: 50,
-                    //     bearing: 50,
-                    //     child: _markerWidget(Icons.arrow_right),
-                    //     latLng: LatLng(10.775818, 106.640497)),
-                    // StaticMarker(
-                    //     width: 50,
-                    //     height: 50,
-                    //     bearing: 75,
-                    //     child: _markerWidget(Icons.arrow_left),
-                    //     latLng: LatLng(10.727416, 106.735597)),
-                    // StaticMarker(
-                    //     width: 50,
-                    //     height: 50,
-                    //     bearing: 100,
-                    //     child: _markerWidget(Icons.arrow_outward_outlined),
-                    //     latLng: LatLng(10.792765, 106.674143)),
                   ]),
         _mapController == null
             ? SizedBox.shrink()
@@ -137,6 +113,60 @@ class _VietmapExampleMapViewState extends State<VietmapExampleMapView> {
       floatingActionButton: Column(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
+          FloatingActionButton(
+            onPressed: () {
+              var line = [
+                LatLng(38.878605, -77.031669),
+                LatLng(38.881946, -77.029609),
+                LatLng(38.884084, -77.020339),
+                LatLng(38.885821, -77.025661),
+                LatLng(38.889563, -77.021884),
+                LatLng(38.892368, -77.019824),
+              ];
+              // var pt = LatLng(38.884017, -77.037076);
+              var pt = LatLng(38.888017, -77.027076);
+
+              var snapped =
+                  VietmapPolyline.nearestLatLngOnLine(line, pt, Unit.miles);
+              print(snapped.toJson());
+              _mapController?.addPolyline(PolylineOptions(
+                geometry: line,
+                polylineColor: Colors.black,
+                polylineWidth: 14.0,
+              ));
+              _mapController?.addCircle(CircleOptions(
+                  geometry: LatLng(38.878605, -77.031669),
+                  circleColor: Colors.orange,
+                  circleRadius: 5));
+              _mapController?.addCircle(CircleOptions(
+                  geometry: LatLng(38.892368, -77.019824),
+                  circleColor: Colors.yellow,
+                  circleRadius: 5));
+              _mapController?.addCircle(CircleOptions(
+                  geometry: snapped.point,
+                  circleColor: Colors.red,
+                  circleRadius: 5));
+
+              _mapController?.addCircle(CircleOptions(
+                  geometry: pt, circleColor: Colors.blue, circleRadius: 5));
+
+              var data = VietmapPolyline.splitRouteByLatLng(line, pt,
+                  unit: Unit.miles);
+
+              print(data);
+              _mapController?.addPolyline(PolylineOptions(
+                geometry: data[0],
+                polylineColor: Colors.green,
+                polylineWidth: 14.0,
+              ));
+              _mapController?.addPolyline(PolylineOptions(
+                geometry: data[1],
+                polylineColor: Colors.red,
+                polylineWidth: 14.0,
+              ));
+            },
+            child: Icon(Icons.calculate),
+          ),
           FloatingActionButton(
             tooltip: 'Add marker',
             onPressed: () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vietmap_flutter_gl
 description: A Flutter map plugin for integrating Vietmap sdk inside a Flutter application, support for show a vector and raster map in Flutter. Supported on Android, iOS platforms .
-version: 1.3.0
+version: 1.3.2
 homepage: https://github.com/vietmap-company
 repository: https://github.com/vietmap-company/flutter-map-sdk
 issue_tracker: https://github.com/vietmap-company/flutter-map-sdk/issues
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/vietmap-company/flutter-map-sdk/issues
 dependencies:
   flutter:
     sdk: flutter
-  vietmap_gl_platform_interface: ^0.1.0
+  vietmap_gl_platform_interface: ^0.1.2
 
 
 flutter:

--- a/vietmap_gl_platform_interface/CHANGELOG.md
+++ b/vietmap_gl_platform_interface/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.1.2 
+- Add `VietmapPolyline` class to handle some polyline properties
 ## 0.1.0
 - Release version `0.1.0`
 ## 0.0.7

--- a/vietmap_gl_platform_interface/lib/src/helper/vietmap_polyline_utils.dart
+++ b/vietmap_gl_platform_interface/lib/src/helper/vietmap_polyline_utils.dart
@@ -1,0 +1,304 @@
+part of vietmap_gl_platform_interface;
+
+enum Unit {
+  meters,
+  millimeters,
+  centimeters,
+  kilometers,
+  acres,
+  miles,
+  nauticalmiles,
+  inches,
+  yards,
+  feet,
+  radians,
+  degrees,
+}
+
+const earthRadius = 6371008.8;
+
+const factors = <Unit, num>{
+  Unit.centimeters: earthRadius * 100,
+  Unit.degrees: earthRadius / 111325,
+  Unit.feet: earthRadius * 3.28084,
+  Unit.inches: earthRadius * 39.370,
+  Unit.kilometers: earthRadius / 1000,
+  Unit.meters: earthRadius,
+  Unit.miles: earthRadius / 1609.344,
+  Unit.millimeters: earthRadius * 1000,
+  Unit.nauticalmiles: earthRadius / 1852,
+  Unit.radians: 1,
+  Unit.yards: earthRadius / 1.0936,
+};
+
+class NearestLatLngResult {
+  final LatLng point;
+  final num distance;
+  final int index;
+  final num location;
+
+  NearestLatLngResult({
+    required this.point,
+    required this.distance,
+    required this.index,
+    required this.location,
+  });
+  toJson() {
+    return {
+      'point': point.toJson(),
+      'distance': distance,
+      'index': index,
+      'location': location,
+    };
+  }
+}
+
+class VietmapPolyline {
+  static NearestLatLngResult _nearestLatLngOnLine(
+    List<LatLng> line,
+    LatLng point, [
+    Unit unit = Unit.kilometers,
+    bool isGetStop = false,
+  ]) {
+    NearestLatLngResult? nearest;
+
+    num length = 0;
+    NearestLatLngResult? stopP;
+    for (var i = 0; i < line.length - 1; ++i) {
+      final startCoordinates = line[i];
+      final stopCoordinates = line[i + 1];
+
+      final startLatLng = startCoordinates;
+      final stopLatLng = stopCoordinates;
+
+      final sectionLength = distance(startLatLng, stopLatLng, unit);
+
+      final start = NearestLatLngResult(
+        point: startLatLng,
+        distance: distance(point, startLatLng, unit),
+        index: i,
+        location: length,
+      );
+
+      final stop = NearestLatLngResult(
+        point: stopLatLng,
+        distance: distance(point, stopLatLng, unit),
+        index: i + 1,
+        location: length + sectionLength,
+      );
+
+      final heightDistance = max(start.distance, stop.distance);
+      final direction = bearing(startLatLng, stopLatLng);
+
+      final perpendicular1 = destination(
+        point,
+        heightDistance,
+        direction + 90,
+        unit,
+      );
+
+      final perpendicular2 = destination(
+        point,
+        heightDistance,
+        direction - 90,
+        unit,
+      );
+
+      final intersectionLatLng = intersects(
+        [perpendicular1, perpendicular2],
+        [startLatLng, stopLatLng],
+      );
+
+      NearestLatLngResult? intersection;
+
+      if (intersectionLatLng != null) {
+        intersection = NearestLatLngResult(
+          point: intersectionLatLng,
+          distance: distance(point, intersectionLatLng, unit),
+          index: i,
+          location: length + distance(startLatLng, intersectionLatLng, unit),
+        );
+      }
+
+      if (nearest == null || start.distance < nearest.distance) {
+        nearest = start;
+      }
+
+      if (stop.distance < nearest.distance) {
+        nearest = stop;
+        stopP = stop;
+      }
+
+      if (intersection != null && intersection.distance < nearest.distance) {
+        nearest = intersection;
+      }
+
+      length += sectionLength;
+    }
+
+    /// A `List<LatLng>` is guaranteed to have at least two points and thus a
+    /// nearest point has to exist.
+
+    return isGetStop ? stopP! : nearest!;
+  }
+
+  static NearestLatLngResult nearestLatLngOnLine(
+    List<LatLng> line,
+    LatLng point, [
+    Unit unit = Unit.kilometers,
+  ]) {
+    return _nearestLatLngOnLine(line, point, unit);
+  }
+
+  static List<List<LatLng>> splitRouteByLatLng(
+    List<LatLng> line,
+    LatLng point, {
+    Unit unit = Unit.kilometers,
+    bool snapInputLatLngToResult = true,
+  }) {
+    var res = _nearestLatLngOnLine(line, point, unit, true);
+    var line1 = line.sublist(0, res.index + 1);
+    if (snapInputLatLngToResult) {
+      line1.add(point);
+    }
+    var line2 = line.sublist(res.index + 1, line.length);
+    if (snapInputLatLngToResult) {
+      line2.insert(0, point);
+    }
+    return [line1, line2];
+  }
+
+  static num distance(LatLng from, LatLng to, [Unit unit = Unit.kilometers]) =>
+      distanceRaw(from, to, unit);
+
+  static num distanceRaw(LatLng from, LatLng to,
+      [Unit unit = Unit.kilometers]) {
+    var dLat = degreesToRadians((to.latitude - from.latitude));
+    var dLon = degreesToRadians((to.longitude - from.longitude));
+    var lat1 = degreesToRadians(from.latitude);
+    var lat2 = degreesToRadians(to.latitude);
+
+    num a =
+        pow(sin(dLat / 2), 2) + pow(sin(dLon / 2), 2) * cos(lat1) * cos(lat2);
+
+    return radiansToLength(2 * atan2(sqrt(a), sqrt(1 - a)), unit);
+  }
+
+  static num degreesToRadians(num degrees) {
+    num radians = degrees.remainder(360);
+    return radians * pi / 180;
+  }
+
+  static num radiansToLength(num radians, [Unit unit = Unit.kilometers]) {
+    var factor = factors[unit];
+    if (factor == null) {
+      throw Exception("$unit units is invalid");
+    }
+    return radians * factor;
+  }
+
+  static num bearingRaw(LatLng start, LatLng end, {bool calcFinal = false}) {
+    // Reverse calculation
+    if (calcFinal == true) {
+      return calculateFinalBearingRaw(start, end);
+    }
+
+    num lng1 = degreesToRadians(start.longitude);
+    num lng2 = degreesToRadians(end.longitude);
+    num lat1 = degreesToRadians(start.latitude);
+    num lat2 = degreesToRadians(end.latitude);
+    num a = sin(lng2 - lng1) * cos(lat2);
+    num b = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(lng2 - lng1);
+
+    return radiansToDegrees(atan2(a, b));
+  }
+
+  static num bearing(LatLng start, LatLng end, {bool calcFinal = false}) =>
+      bearingRaw(start, end, calcFinal: calcFinal);
+
+  static num calculateFinalBearingRaw(LatLng start, LatLng end) {
+    // Swap start & end
+    num reverseBearing = bearingRaw(end, start) + 180;
+    return reverseBearing.remainder(360);
+  }
+
+  /// Calculates Final Bearing
+  static num calculateFinalBearing(LatLng start, LatLng end) =>
+      calculateFinalBearingRaw(start, end);
+
+  static num radiansToDegrees(num radians) {
+    num degrees = radians.remainder(2 * pi);
+    return degrees * 180 / pi;
+  }
+
+  static LatLng destinationRaw(LatLng origin, num distance, num bearing,
+      [Unit unit = Unit.kilometers]) {
+    num longitude1 = degreesToRadians(origin.longitude);
+    num latitude1 = degreesToRadians(origin.latitude);
+    num bearingRad = degreesToRadians(bearing);
+    num radians = lengthToRadians(distance, unit);
+
+    // Main
+    num latitude2 = asin(sin(latitude1) * cos(radians) +
+        cos(latitude1) * sin(radians) * cos(bearingRad));
+    num longitude2 = longitude1 +
+        atan2(sin(bearingRad) * sin(radians) * cos(latitude1),
+            cos(radians) - sin(latitude1) * sin(latitude2));
+    return LatLng(
+      radiansToDegrees(latitude2).toDouble(),
+      radiansToDegrees(longitude2).toDouble(),
+    );
+  }
+
+  static LatLng destination(LatLng origin, num distance, num bearing,
+          [Unit unit = Unit.kilometers]) =>
+      destinationRaw(origin, distance, bearing, unit);
+
+  static num lengthToRadians(num distance, [Unit unit = Unit.kilometers]) {
+    num? factor = factors[unit];
+    if (factor == null) {
+      throw Exception("$unit units is invalid");
+    }
+    return distance / factor;
+  }
+
+  static LatLng? intersects(List<LatLng> line1, List<LatLng> line2) {
+    if (line1.length != 2) {
+      throw Exception('line1 must only contain 2 coordinates');
+    }
+
+    if (line2.length != 2) {
+      throw Exception('line2 must only contain 2 coordinates');
+    }
+
+    final x1 = line1.first.longitude;
+    final y1 = line1.first.latitude;
+    final x2 = line1.last.longitude;
+    final y2 = line1.last.latitude;
+    final x3 = line2.first.longitude;
+    final y3 = line2.first.latitude;
+    final x4 = line2.last.longitude;
+    final y4 = line2.last.latitude;
+
+    final denom = (y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1);
+
+    if (denom == 0) {
+      return null;
+    }
+
+    final numeA = (x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3);
+    final numeB = (x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3);
+
+    final uA = numeA / denom;
+    final uB = numeB / denom;
+
+    if (uA >= 0 && uA <= 1 && uB >= 0 && uB <= 1) {
+      final x = x1 + uA * (x2 - x1);
+      final y = y1 + uA * (y2 - y1);
+
+      return LatLng(y, x);
+    }
+
+    return null;
+  }
+}

--- a/vietmap_gl_platform_interface/lib/vietmap_gl_platform_interface.dart
+++ b/vietmap_gl_platform_interface/lib/vietmap_gl_platform_interface.dart
@@ -27,3 +27,4 @@ part 'src/helper/vietmap_polygon_util.dart';
 part 'src/helper/vietmap_polyline_decode.dart';
 part 'src/helper/vietmap_spherical_util.dart';
 part 'extensions/color_extension.dart';
+part 'src/helper/vietmap_polyline_utils.dart';

--- a/vietmap_gl_platform_interface/pubspec.yaml
+++ b/vietmap_gl_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vietmap_gl_platform_interface
 description: A common platform interface for the vietmap_flutter_gl plugin.
-version: 0.1.0
+version: 0.1.2
 homepage: https://github.com/vietmap-company
 
 dependencies:


### PR DESCRIPTION
## 1.3.2, Dec 11, 2023
* Provide `nearestLatLngOnLine` and `splitRouteByLatLng` function inside `VietmapPolyline` class, which help show shipper/vehicle location on route and remove route traveled by shipper/vehicle.
* `splitRouteByLatLng` will split route into 2 parts, which are `routeBeforeLatLng` and `routeAfterLatLng`, you can use one of them to to update the route of shipper/vehicle traveled.
* Create `VietmapPolyline` class to handle more complex polyline